### PR TITLE
chore: update kafka and redpanda configuration

### DIFF
--- a/ops/dev-stack/debezium/config/pg-src.json
+++ b/ops/dev-stack/debezium/config/pg-src.json
@@ -13,7 +13,7 @@
   "schema.include.list": "public",
   "plugin.name": "pgoutput",
   "key.converter": "io.confluent.connect.avro.AvroConverter",
-  "key.converter.schema.registry.url": "http://redpanda-0.redpanda.redpanda.svc.cluster.local:8081",
+  "key.converter.schema.registry.url": "http://redpanda.kafka.svc.cluster.local:8081",
   "value.converter": "io.confluent.connect.avro.AvroConverter",
-  "value.converter.schema.registry.url": "http://redpanda-0.redpanda.redpanda.svc.cluster.local:8081"
+  "value.converter.schema.registry.url": "http://redpanda.kafka.svc.cluster.local:8081"
 }

--- a/ops/dev-stack/debezium/config/s3-sink.json
+++ b/ops/dev-stack/debezium/config/s3-sink.json
@@ -10,7 +10,7 @@
   "topics": "debezium.public.user,debezium.public.payment",
   "key.converter": "org.apache.kafka.connect.storage.StringConverter",
   "value.converter": "io.confluent.connect.avro.AvroConverter",
-  "value.converter.schema.registry.url": "http://redpanda-0.redpanda.redpanda.svc.cluster.local:8081",
+  "value.converter.schema.registry.url": "http://redpanda.kafka.svc.cluster.local:8081",
   "file.compression.type": "none",
   "format.output.fields": "key,value,offset,timestamp"
 }

--- a/ops/dev-stack/debezium/deployment.yaml
+++ b/ops/dev-stack/debezium/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dbz-connect
+  namespace: kafka
 spec:
   replicas: 1
   selector:
@@ -23,23 +24,23 @@ spec:
           mountPath: "/connectors"
         env:
           - name: BOOTSTRAP_SERVERS
-            value: "redpanda.redpanda.svc.cluster.local:9093"
+            value: redpanda.kafka.svc.cluster.local:9093
           - name: GROUP_ID
             value: "1"
           - name: CONFIG_STORAGE_TOPIC
-            value: "users.configs"
+            value: users.configs
           - name: OFFSET_STORAGE_TOPIC
-            value: "users.offset"
+            value: users.offset
           - name: STATUS_STORAGE_TOPIC
-            value: "users.status"
+            value: users.status
           - name: KEY_CONVERTER
-            value: " io.confluent.connect.avro.AvroConverter"
+            value:  io.confluent.connect.avro.AvroConverter
           - name: VALUE_CONVERTER
-            value: " io.confluent.connect.avro.AvroConverter"
+            value: io.confluent.connect.avro.AvroConverter
           - name: CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL
-            value: "http://redpanda.redpanda.svc.cluster.local:8081"
+            value: http://redpanda.kafka.svc.cluster.local:8081
           - name: CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL
-            value: "http://redpanda.redpanda.svc.cluster.local:8081"
+            value: http://redpanda.kafka.svc.cluster.local:8081
       # TODO: This is a hack to get the connectors to load. Need to figure out how to do this properly. 
       # https://debezium.io/documentation/reference/stable/tutorial.html#starting-kafka-connect
       # could also look at using lifecycle hooks with postStart

--- a/ops/dev-stack/debezium/job/configure_kafka_connectors.yaml
+++ b/ops/dev-stack/debezium/job/configure_kafka_connectors.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: configure-kafka-connectors
+  namespace: kafka
 spec:
   template:
     spec:

--- a/ops/dev-stack/kustomization.yaml
+++ b/ops/dev-stack/kustomization.yaml
@@ -28,6 +28,7 @@ resources:
 
 configMapGenerator:
   - name: kafka-config
+    namespace: kafka
     files:
       - debezium/config/s3-sink.json
       - debezium/config/pg-src.json

--- a/ops/dev-stack/redpanda/console/values.yaml
+++ b/ops/dev-stack/redpanda/console/values.yaml
@@ -1,0 +1,30 @@
+resources:
+  limits:
+    cpu: 1
+    memory: 2Gi
+  requests:
+    cpu: 100m
+    memory: 512Mi
+
+console:
+  config:
+    kafka:
+      brokers: ["redpanda-0.redpanda.kafka.svc.cluster.local:9093"]
+      sasl:
+        enabled: false
+      tls:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        urls: ["http://redpanda-0.redpanda.kafka.svc.cluster.local:8081"] 
+    connect:
+      enabled: true
+      clusters: 
+        - name: dbz-connect
+          url: http://dbz-connect.kafka.svc.cluster.local:8083
+    redpanda:
+      adminApi:
+        enabled: true
+        urls: ["http://redpanda-0.redpanda.kafka.svc.cluster.local:9644"]
+    logger:
+      level: debug # Valid values are debug, info, warn, error, and fatal

--- a/ops/dev-stack/redpanda/values.yaml
+++ b/ops/dev-stack/redpanda/values.yaml
@@ -1,39 +1,15 @@
 commonLabels:
   service: redpanda
 console:
-  enabled: true
+  enabled: false
   configmap:
-    create: false
+    create: true
   secret:
-    create: false
+    create: true
   deployment:
     create: true
-  config:
-    kafka:
-      brokers: 
-      - redpanda:9093
-      schemaRegistry:
-        enabled: true
-        urls: 
-        - redpanda:8081
-    redpanda:
-      adminApi:
-        enabled: true
-        urls: 
-        - redpanda:9644 
-    connect:
-      enabled: true
-      clusters: 
-        - name: dbz-connect
-          url: http://dbz-connect.default.svc.cluster.local:8083
-          tls:
-            enabled: false 
-    # sasl:
-    #   enabled: true
-    #   username: consoles
-    #   password: consolepass
-    # tls:
-    #   enabled: false
+  config: {}
+
 tls:
   enabled: false 
 storage:

--- a/tiltfile
+++ b/tiltfile
@@ -76,19 +76,26 @@ k8s_resource("minio", port_forwards=['9001','9000'], labels="object", resource_d
 # https://github.com/redpanda-data-blog/2022-redpanda-duckdb/blob/main/docker-compose.yml
 # https://github.com/redpanda-data/helm-charts
 load('ext://namespace', 'namespace_create')
-namespace_create('redpanda')
+namespace_create('kafka')
 load('ext://helm_remote', 'helm_remote')
 values = [
     "./ops/dev-stack/redpanda/values.yaml",
                 # "server=[serviceAccount.create=false,serviceAccount.name=argo-workflows,service.type=NodePort,extraArgs=[--secure=false]]", "--debug=true"
             ]
-helm_remote('redpanda', namespace='redpanda', repo_url='https://charts.redpanda.com/', values=values)
+helm_remote('redpanda', namespace='kafka', repo_url='https://charts.redpanda.com/', values=values)
 k8s_resource("redpanda-configuration", labels="kafka",resource_deps=["redpanda"])
-k8s_resource("redpanda-console",port_forwards=['8080'], labels="kafka",resource_deps=["redpanda"])
+## Redpanda Console
+load('ext://helm_remote', 'helm_remote')
+values = [
+    "./ops/dev-stack/redpanda/console/values.yaml",
+            ]
+helm_remote('console', namespace='kafka', repo_url='https://charts.redpanda.com/', values=values)
+k8s_resource("redpanda-configuration", labels="kafka",resource_deps=["redpanda"])
+k8s_resource("console",port_forwards=['8080'], labels="kafka",resource_deps=["redpanda" ])
 k8s_resource("redpanda-post-upgrade", labels="kafka", resource_deps=["redpanda"],)
 k8s_resource("redpanda", labels="kafka")
 k8s_resource("configure-kafka-connectors", labels="kafka")
-k8s_resource("dbz-connect", port_forwards=[], labels="kafka", resource_deps=["redpanda", "redpanda-console"])
+k8s_resource("dbz-connect", port_forwards=["8083"], labels="kafka", resource_deps=["redpanda"])
 
 
 k8s_yaml(blob("""
@@ -184,7 +191,7 @@ run_argo_workflow = """\
 	argo --namespace=argo logs $ARGO_TASK_NAME --follow
     argo --namespace=argo get $ARGO_TASK_NAME --output=json | jq -r '.status.phase' | grep -q 'Succeeded'
 """
-local_resource("run-argo-workflow", run_argo_workflow, resource_deps=["argo-workflows-server", "create-argo-server-token"],  labels="argo", trigger_mode=TRIGGER_MODE_MANUAL)
+local_resource("run-argo-workflow", run_argo_workflow, resource_deps=["argo-workflows-server", "create-argo-server-token"],  labels="argo", trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False)
 
 # k8s_resource("datagen", labels="datagen",resource_deps=["psql_db"])
 # Extensions are open-source, pre-packaged functions that extend Tilt


### PR DESCRIPTION
Fix: 
https://github.com/kcirtapfromspace/database_thing/issues/32

This commit updates the configuration files for Kafka and Redpanda.
Specifically, it changes the schema registry URLs to use the new service name
`redpanda.kafka.svc.cluster.local` instead of
`redpanda-0.redpanda.redpanda.svc.cluster.local`.
It also adds support for the
`process.env.PORT` environment variable in the `server.ts` file.
Additionally, it changes the namespace for the `dbz-connect` deployment and
`configure-kafka-connectors` job to `kafka`.
Finally, it adds a new `console` Helm chart for Redpanda and updates the `values.yaml`
file for Redpanda to disable the console by default.